### PR TITLE
Provide a permalink to reviews, to make it easier to share reviews.

### DIFF
--- a/docs/cpanratings/display/short_review.html
+++ b/docs/cpanratings/display/short_review.html
@@ -43,7 +43,7 @@
   module_param = review.module ? ";module=" _ review.module : ""; 
   module_param | uri %]">edit</a>
 [% END %]
-(<a href="#[% review.id %]">permalink</a>)
+(<a href="/dist/[% review.distribution | uri %]#[% review.id %]">permalink</a>)
 </p>
 
 <div class="helpfulq">Was this review helpful to you?&nbsp;


### PR DESCRIPTION
This may be better handled by providing a "view single review" page to which this would link (e.g. `/rating/1234` - let me know if you'd prefer that, and I can rustle up a pull request implementing that instead.
