### PR TITLE
Fix Perlsphere link (.net not .org)

### DIFF
--- a/docs/learn/faq/index.html
+++ b/docs/learn/faq/index.html
@@ -58,7 +58,7 @@
         &gt; <a href="http://blogs.perl.org/">http://blogs.perl.org/</a>
     </li>
     <li>
-        &gt; <a href="http://perlsphere.org/">Perlsphere</a> - blog aggregator
+        &gt; <a href="http://perlsphere.net/">Perlsphere</a> - blog aggregator
     </li>
     <li>
         &gt; <a href="http://ironman.enlightenedperl.org/">Ironman</a> - blog aggregator


### PR DESCRIPTION
consistent with other perlsphere links
