### PR TITLE
Email::MIME requires encoding & charset

### DIFF
--- a/docs/learn/examples/email.html
+++ b/docs/learn/examples/email.html
@@ -13,7 +13,11 @@ my $message = Email::MIME->create(
     To      => 'friend@example.com',
     Subject => 'Happy birthday!',
   ],
-  body_str => 'Happy birthday to you!',
+  attributes => {
+    encoding => 'quoted-printable',
+    charset  => 'ISO-8859-1',
+  },
+  body_str => "Happy birthday to you!\n",
 );
 
 # send the message


### PR DESCRIPTION
The "Sending an email" example does not work as written.  You get the error "body_str was given, but no charset is defined at /usr/local/share/perl/5.10.1/Email/MIME.pm line 243".  See [this question](http://stackoverflow.com/q/9254986/8355) on Stack Overflow.

Also, an email body should normally end with a newline
