### PR TITLE
Fixed Broken Link

### DIFF
--- a/docs/www/about.html
+++ b/docs/www/about.html
@@ -187,7 +187,7 @@
         <a href="http://www.linuxjournal.com/issue61/3394.html">Linux Journal interview</a> (May 1999)
     </li>
     <li>
-        <a href="http://archive.salon.com/21st/feature/1998/10/cov_13feature.html">The Joy Of Perl</a>
+        <a href="http://www.salon.com/1998/10/13/feature_269/">The Joy Of Perl</a>
     </li>
 </ul>
 


### PR DESCRIPTION
The Link to "the Joy of Perl" in about.html was broken and is now fixed.
