### PR TITLE
perl 5.18.2 has been released

### DIFF
--- a/docs/shared/tpl/stats.html
+++ b/docs/shared/tpl/stats.html
@@ -15,9 +15,9 @@
         perl_age => 26,
 
         # Perl version
-        perl_version => '5.18.1',
+        perl_version => '5.18.2',
         perl_version_link =>
-          'http://search.cpan.org/dist/perl-5.18.1/pod/perldelta.pod',
+          'http://search.cpan.org/dist/perl-5.18.2/pod/perldelta.pod',
 
         perl_download_link => 'http://search.cpan.org/dist/perl/',
 


### PR DESCRIPTION
Tiny update: 5.18.2 exists now.
