### PR TITLE
Switch freenode webchat to scrollback (#104)

### DIFF
--- a/docs/www/community.html
+++ b/docs/www/community.html
@@ -70,7 +70,7 @@
                     <a href="http://www.irc.perl.org">irc.perl.org</a> (<a href="http://www.irc.perl.org/channels.html">channel list</a>)
                 </li>
                 <li>
-                    <a href="http://scrollback.io/perl">The #perl channel on Scrollback</a>
+                    <a href="http://scrollback.io/perl">Freeenode's #perl channel on Scrollback</a>
                 </li>
             </ul>
 


### PR DESCRIPTION
This replaces the "Freenode's #perl channel" link with "The #perl channel on Scrollback".
