### PR TITLE
Add note about checking for known issues/outages

### DIFF
--- a/docs/noc/index.html
+++ b/docs/noc/index.html
@@ -120,6 +120,13 @@ Some of the services we provide:
 </table>
 
 <h2>Reporting Issues</h2>
+
+<p>
+Before reporting an issue check <a href="http://log.perl.org/">log.perl.org</a> 
+and <a href="https://twitter.com/perlorg">the perl.org twitter feed</a> to
+ensure that there are no known issues/outages.
+</p>
+
 <p>
 To report content issues with <tt>{www,learn,dev,lists}.perl.org</tt>, please
 use our <a href="https://github.com/perlorg/perlweb/issues?state=open">


### PR DESCRIPTION
Add a short note asking users to check for known issues/outages using log.perl.org and the perlweb twitter feed, before raising an issue.
