### PR TITLE
summarize the p5p SOC for the web

### DIFF
--- a/docs/dev/perl5/lists.html
+++ b/docs/dev/perl5/lists.html
@@ -1,10 +1,33 @@
 [% page.title="Mailing Lists" %]
 
-<p>Some useful mailing lists if you want to get involved</p>
+<p>Some useful mailing lists if you want to get involved:</p>
 
 <h4><a href="http://lists.perl.org/list/perl5-porters.html">Perl 5 Porters</a></h4>
 <p>The primary development list for perl5</p>
 
+<p>
+The official forum for the development of perl is the perl5-porters mailing
+list, mentioned above, and its bugtracker at rt.perl.org. All participants in
+discussion there are expected to adhere to a standard of conduct.
+</p>
+
+<ul>
+<li>Always be civil.</li>
+<li>Heed the moderators.</li>
+</ul>
+
+<p>
+Civility is simple: stick to the facts while avoiding demeaning remarks and
+sarcasm. It is not enough to be factual.  You must also be civil.  Responding
+in kind to incivility is not acceptable.
+</p>
+
+<p>
+Failure to be civil and failure to heed the moderators will be answered by
+removal from the list.  For more specifics, consult the file
+<tt>pod/perlpolicy.pod</tt> in the perl5 git repository.
+</p>
+
 <h4><a href="http://lists.perl.org/list/perl5-changes.html">Perl 5 Changes</a></h4>
-        <p>Receive an email every time a change is committed to perl5</p>
+          <p>Receive an email every time a change is committed to perl5</p>
 


### PR DESCRIPTION
I'd like to get this on the web in an easy-to-link-to location so we can link to it from the p5p welcome message.