### PR TITLE
Fix link to the Koha project on the mainpage

### DIFF
--- a/docs/perl4lib/index.html
+++ b/docs/perl4lib/index.html
@@ -57,7 +57,7 @@ if you have any suggestions.
 <ul>
 <li><a href="http://www.greenstone.org">Greenstone</a>: a suite of software for building and distributing digital library collections.</li>
 <li><a href="http://www.eprints.org/">Eprints</a>: a complete system for creating and distributing online archives.</a></li>
-<li><a href="http://www.koha.org">Koha</a>: a full featured open source library system.</li>
+<li><a href="http://koha-community.org/">Koha</a>: a full featured open source library system.</li>
 <li><a href="http://github.com/unistra/eplouribousse">Eplouribousse</a>want to remove redundant magazines over multiple libs? eplouribousse will help you! (only in french)</li>
 </ul>
 


### PR DESCRIPTION
The link to the Koha project is wrong, it should be
http://koha-community.org