### PR TITLE
remove mailto, use tt format for email address

### DIFF
--- a/docs/shared/error/error.html
+++ b/docs/shared/error/error.html
@@ -34,7 +34,7 @@ error_uri | uri %]</tt>. <br /><br />
 
 Ouch!  The server made a boo-boo.  In other words: We messed up!
 Sincere apologies all around.  The server has already sent angry mails
-to the staff, so please be kind if you also choose to contact us by email: <tt>webmaster at perl.org</tt>.
+to the staff, so please be kind if you also choose to contact us by email <tt>webmaster at perl.org</tt>.
 
 [% ELSE %]
 

--- a/docs/shared/error/error.html
+++ b/docs/shared/error/error.html
@@ -24,7 +24,7 @@ error_uri | uri %]</tt>. <br /><br />
 <script type="text/javascript" 
     src="https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
 
-Go to <a href="/">the front page</a> or <a href="mailto:ask@develooper.com">send mail to the staff</a>.
+Go to <a href="/">the front page</a> or <a href="mailto:webmaster@perl.org">send mail to the staff</a>.
 
 [% ELSIF error == 500 %]
 
@@ -32,15 +32,15 @@ Go to <a href="/">the front page</a> or <a href="mailto:ask@develooper.com">send
 <i>[% error_text %]</i></p><p>
 [% END %]
 
-Ouch!  The server made a boo-boo.  In other words: We #$%^#$ up!
+Ouch!  The server made a boo-boo.  In other words: We messed up!
 Sincere apologies all around.  The server has already sent angry mails
 to the staff, so please be kind if you also choose to <a
-href="mailto:ask@develooper.com">send a mail</a>.
+href="mailto:webmaster@perl.org">send a mail</a>.
 
 [% ELSE %]
 
 Unhandled error!  UFO's in the sky?  Call the X-Files!  Or <a
-href="mailto:ask@develooper.com">send a mail</a>.
+href="mailto:webmaster@perl.org">send a mail</a>.
 
 [% END %]
 </p>

--- a/docs/shared/error/error.html
+++ b/docs/shared/error/error.html
@@ -24,7 +24,7 @@ error_uri | uri %]</tt>. <br /><br />
 <script type="text/javascript" 
     src="https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
 
-Go to <a href="/">the front page</a> or <a href="mailto:webmaster@perl.org">send mail to the staff</a>.
+  Go to <a href="/">the front page</a> or send mail to the staff at <tt>webmaster at perl.org</tt>.
 
 [% ELSIF error == 500 %]
 
@@ -34,8 +34,7 @@ Go to <a href="/">the front page</a> or <a href="mailto:webmaster@perl.org">send
 
 Ouch!  The server made a boo-boo.  In other words: We messed up!
 Sincere apologies all around.  The server has already sent angry mails
-to the staff, so please be kind if you also choose to <a
-href="mailto:webmaster@perl.org">send a mail</a>.
+to the staff, so please be kind if you also choose to contact us by email: <tt>webmaster at perl.org</tt>.
 
 [% ELSE %]
 

--- a/docs/www/error/error.html
+++ b/docs/www/error/error.html
@@ -25,7 +25,7 @@ error_uri | uri %]</tt>. </P>
     src="https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
 
 <P>Go to <a href="/">the front page</a> or <a
-href="mailto:ask@develooper.com">send mail to the staff</a>.</P>
+href="mailto:webmaster@perl.org">send mail to the staff</a>.</P>
 
 [% ELSIF error == 500 %]
 
@@ -33,16 +33,16 @@ href="mailto:ask@develooper.com">send mail to the staff</a>.</P>
 <i>[% error_text %]</i></p><p>
 [% END %]
 
-Ouch!  The server made a boo-boo.  In other words: We #$%^#$ up!
+Ouch!  The server made a boo-boo.  In other words: We messed up!
 Sincere apologies all around.  The server has already sent angry mails
 to the staff, so please be kind if you also choose to <a
-href="mailto:ask@develooper.com">send a mail</a>.
+href="mailto:webmaster@perl.org">send a mail</a>.
 
 [% ELSE %]
 
 It's a bird!  It's a plane!  No, it's a flying camel!  Unhandled
 error!  UFO's in the sky?  Call the X-Files!  Or <a
-href="mailto:ask@develooper.com">send a mail</a>.
+href="mailto:webmaster@perl.org">send a mail</a>.
 
 [% END %]
 </p>

--- a/docs/www/error/error.html
+++ b/docs/www/error/error.html
@@ -24,8 +24,7 @@ error_uri | uri %]</tt>. </P>
 <script type="text/javascript" 
     src="https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
 
-<P>Go to <a href="/">the front page</a> or <a
-href="mailto:webmaster@perl.org">send mail to the staff</a>.</P>
+<P>Go to <a href="/">the front page</a> or send mail to the staff at <tt>webmaster at perl.org</tt></P>
 
 [% ELSIF error == 500 %]
 
@@ -35,14 +34,12 @@ href="mailto:webmaster@perl.org">send mail to the staff</a>.</P>
 
 Ouch!  The server made a boo-boo.  In other words: We messed up!
 Sincere apologies all around.  The server has already sent angry mails
-to the staff, so please be kind if you also choose to <a
-href="mailto:webmaster@perl.org">send a mail</a>.
+to the staff, so please be kind if you also choose to contact us by email <tt>webmaster at perl.org</tt>.
 
 [% ELSE %]
 
-It's a bird!  It's a plane!  No, it's a flying camel!  Unhandled
-error!  UFO's in the sky?  Call the X-Files!  Or <a
-href="mailto:webmaster@perl.org">send a mail</a>.
+It's a bird!  It's a plane!  No, it's a flying camel!  Unhandled error!  
+UFO's in the sky?  Call the X-Files!  Or send a mail to <tt>webmaster at perl.org</tt>.
 
 [% END %]
 </p>


### PR DESCRIPTION
Following on from https://github.com/perlorg/perlweb/pull/201:

* change email address
* remove mailto, use `<tt>` style
* remove implied profanity