### PR TITLE
Regenerate HTML for 5.18.1 and 5.22.2.

### DIFF
--- a/docs/dev/perl5/news/2013/perl-5.18.1.html
+++ b/docs/dev/perl5/news/2013/perl-5.18.1.html
@@ -18,10 +18,10 @@ mirror or find it at:
 SHA1 digests for this release are:
 </p>
 
-<p>
-eb6b402682168a9735b2806d09c1ca5d567b2de8 perl-5.18.1.tar.bz2
-524a10ba76e394e5d40b319f5609cb4c4a96f564 perl-5.18.1.tar.gz
-</p>
+<pre>
+    eb6b402682168a9735b2806d09c1ca5d567b2de8  perl-5.18.1.tar.bz2
+    524a10ba76e394e5d40b319f5609cb4c4a96f564  perl-5.18.1.tar.gz
+</pre>
 
 <p>
 You can find a full list of changes in the file "perldelta.pod" located in

--- a/docs/dev/perl5/news/2016/perl-5.22.2.html
+++ b/docs/dev/perl5/news/2016/perl-5.22.2.html
@@ -18,11 +18,11 @@ mirror or find it at:
 SHA1 digests for this release are:
 </p>
 
-<p>
-2b84a711694be9a10e558c38c9aa43d86c7329a9 perl-5.22.2.tar.gz
-e2f465446dcd45a7fa3da696037f9ebe73e78e55 perl-5.22.2.tar.bz2
-43b599def873413012fc8bcfd0a64bbce40b4ed2 perl-5.22.2.tar.xz
-</p>
+<pre>
+    2b84a711694be9a10e558c38c9aa43d86c7329a9  perl-5.22.2.tar.gz
+    e2f465446dcd45a7fa3da696037f9ebe73e78e55  perl-5.22.2.tar.bz2
+    43b599def873413012fc8bcfd0a64bbce40b4ed2  perl-5.22.2.tar.xz
+</pre>
 
 <p>
 You can find a full list of changes in the file "perldelta.pod" located in


### PR DESCRIPTION
There were errors in the formatting of my (local) input files that meant that
the SHA lines were not properly rendering at:

        http://dev.perl.org/perl5/news/2013/perl-5.18.1.html
        http://dev.perl.org/perl5/news/2016/perl-5.22.2.html