### PR TITLE
Update examples to use Path::Tiny instead of Path::Class

### DIFF
--- a/docs/learn/examples/directory_list.html
+++ b/docs/learn/examples/directory_list.html
@@ -5,17 +5,18 @@
 
 [% WRAPPER code_chunk -%]
 [% INCLUDE "examples/script_head.html" -%]
-use Path::Class;
+use Path::Tiny;
 
-my $dir = dir('foo','bar'); # foo/bar
+my $dir = path('foo','bar'); # foo/bar
 
 # Iterate over the content of foo/bar
-while (my $file = $dir->next) {
+my $iter = $dir->iterator;
+while (my $file = $iter->next) {
     
     # See if it is a directory and skip
     next if $file->is_dir();
     
     # Print out the file name and path
-    print $file->stringify . "\n";
+    print "$file\n";
 }
 [%- END %]

--- a/docs/learn/examples/read_write_file.html
+++ b/docs/learn/examples/read_write_file.html
@@ -6,15 +6,16 @@
 <h4>Writing to a file</h4>
 [% WRAPPER code_chunk -%]
 [% INCLUDE "examples/script_head.html" -%]
-use Path::Class;
+use Path::Tiny;
 use autodie; # die if problem reading or writing a file
 
-my $dir = dir("/tmp"); # /tmp
+my $dir = path("/tmp"); # /tmp
 
-my $file = $dir->file("file.txt"); # /tmp/file.txt
+my $file = $dir->child("file.txt"); # /tmp/file.txt
 
 # Get a file_handle (IO::File object) you can write to
-my $file_handle = $file->openw();
+# with a UTF-8 encoding layer
+my $file_handle = $file->openw_utf8();
 
 my @list = ('a', 'list', 'of', 'lines');
 
@@ -27,25 +28,26 @@ foreach my $line ( @list ) {
 
 <h4>Appending to a file</h4>
 [% WRAPPER code_chunk -%]
-# As above but use open('>>') instead of openw()
-my $file_handle = $file->open('>>');
+# As above but use opena_utf8() instead of openw_utf8()
+my $file_handle = $file->opena_utf8();
 [%- END %]
 
 <h4>Reading a file</h4>
 [% WRAPPER code_chunk -%]
 [% INCLUDE "examples/script_head.html" -%]
-use Path::Class;
+use Path::Tiny;
 use autodie; # die if problem reading or writing a file
 
-my $dir = dir("/tmp"); # /tmp
+my $dir = path("/tmp"); # /tmp
 
-my $file = $dir->file("file.txt");
+my $file = $dir->child("file.txt");
 
 # Read in the entire contents of a file
-my $content = $file->slurp();
+my $content = $file->slurp_utf8();
 
-# openr() returns an IO::File object to read from
-my $file_handle = $file->openr();
+# openr_utf8() returns an IO::File object to read from
+# with a UTF-8 decoding layer
+my $file_handle = $file->openr_utf8();
 
 # Read in line at a time
 while( my $line = $file_handle->getline() ) {
@@ -55,12 +57,10 @@ while( my $line = $file_handle->getline() ) {
 [%- END %]
 
 <p>
-    [% PROCESS cpan_link module=>'Path::Class' %] makes working with
-    directories ([% PROCESS cpan_link module=>'Path::Class::Dir' %]) and 
-    files ([% PROCESS cpan_link module=>'Path::Class::File' %]) clean 
-    and easy to do.
-    Try to work with file() or dir() objects throughout your code, 
-    but remember if you are calling other Perl modules you will often need 
+    [% PROCESS cpan_link module=>'Path::Tiny' %] makes working with
+    directories and files clean and easy to do. Use path() to create a
+    Path::Tiny object for any file path you want to operate on,
+    but remember if you are calling other Perl modules you may need
     to convert the object to a string using 'stringify':
     [% WRAPPER code_chunk -%]
     $file->stringify();


### PR DESCRIPTION
Also: read and write operations using a UTF-8 layer as this should be default for text operations such as in these examples, and as Path::Tiny is more efficient it's less important when you create Path::Tiny objects or stringify them.