### PR TITLE
Update perlweb for 5.26.0

### DIFF
--- a/docs/shared/tpl/stats.html
+++ b/docs/shared/tpl/stats.html
@@ -15,9 +15,9 @@
         perl_age => 29,
 
         # Perl version
-        perl_version => '5.24.1',
+        perl_version => '5.26.0',
         perl_version_link =>
-          'http://search.cpan.org/dist/perl-5.24.1/pod/perldelta.pod',
+          'http://search.cpan.org/dist/perl-5.26.0/pod/perldelta.pod',
 
         perl_download_link => 'http://search.cpan.org/dist/perl/',
 


### PR DESCRIPTION
So yeah, we got 5.26.0 now.

I'm not sure about the rest of the numbers though.