### PR TITLE
Bump the perl age to 30 instead of 29.

### DIFF
--- a/docs/shared/tpl/stats.html
+++ b/docs/shared/tpl/stats.html
@@ -12,7 +12,7 @@
         platforms => 100,
 
         # Years since December 18, 1987
-        perl_age => 29,
+        perl_age => 30,
 
         # Perl version
         perl_version => '5.26.1',


### PR DESCRIPTION
It has been over 30 years since Dec 1987.