### PR TITLE
Bump version to 5.28.0

### DIFF
--- a/docs/shared/tpl/stats.html
+++ b/docs/shared/tpl/stats.html
@@ -15,7 +15,7 @@
         perl_age => 30,
 
         # Perl version
-        perl_version => '5.26.2',
+        perl_version => '5.28.0',
         perl_version_link =>
           'https://metacpan.org/pod/perldelta',
 


### PR DESCRIPTION
cf. https://www.nntp.perl.org/group/perl.perl5.porters/2018/06/msg251240.html

Needs https://www.cpan.org/src/5.0 updated as well however, as at the time of this commit/PR, that place doesn't have the 5.28 tarballs yet.