### PR TITLE
Update Modern Perl entry for learn.perl.org

### DIFF
--- a/docs/learn/books/books_content.html
+++ b/docs/learn/books/books_content.html
@@ -67,10 +67,10 @@
 [% PROCESS book_block
     name => 'modernperl',
     title => 'Modern Perl',
-    isbn => '0977920178',
+    isbn => '1680500880',
     link => 'http://www.onyxneon.com/books/modern_perl/index.html',
-    author => 'by chromatic (2012).',
-    description => "Modern Perl is suitable for programmers of every level. It's more than a Perl tutorial—only Modern Perl focuses on Perl 5.12 and 5.14, to demonstrate the latest and most effective time-saving features. Only Modern Perl explains how and why the language works, to let you unlock the full power of Perl.",
+    author => 'by chromatic (2015).',
+    description => "Modern Perl is suitable for programmers of every level. It's more than a Perl tutorial—only Modern Perl focuses on Perl 5.20 and 5.22, to demonstrate the latest and most effective time-saving features. Only Modern Perl explains how and why the language works, to let you unlock the full power of Perl.",
 %]
 
 [% PROCESS book_block

--- a/docs/learn/books_content.html
+++ b/docs/learn/books_content.html
@@ -56,10 +56,10 @@
 [% PROCESS book_block
     name => 'modernperl',
     title => 'Modern Perl',
-    isbn => '0977920178',
+    isbn => '1680500880',
     link => 'http://www.onyxneon.com/books/modern_perl/index.html',
-    author => 'by chromatic (2012).',
-    description => "Modern Perl is suitable for programmers of every level. It's more than a Perl tutorial—only Modern Perl focuses on Perl 5.12 and 5.14, to demonstrate the latest and most effective time-saving features. Only Modern Perl explains how and why the language works, to let you unlock the full power of Perl.",
+    author => 'by chromatic (2015).',
+    description => "Modern Perl is suitable for programmers of every level. It's more than a Perl tutorial—only Modern Perl focuses on Perl 5.20 and 5.22, to demonstrate the latest and most effective time-saving features. Only Modern Perl explains how and why the language works, to let you unlock the full power of Perl.",
 %]
 
 [% PROCESS book_block


### PR DESCRIPTION
Previously updated at https://www.perl.org/books/library.html by https://github.com/perlorg/perlweb/pull/253 but apparently there is a very similar list at https://learn.perl.org/books/.