### PR TITLE
Rename Perl 6 references to Raku, and Perl 5 to Perl

### DIFF
--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -27,12 +27,12 @@ description => 'Resources and useful links for developers.',
     </p>
   </div>
   <div class="col-xs-12 col-sm-6">
-    <h3>Perl 6</h3>
+    <h3>Raku</h3>
     <p>
-        <a href="http://www.perl6.org/">http://www.perl6.org/</a>
+        <a href="http://www.raku.org/">http://www.raku.org/</a>
     </p>
     <p>
-        The <a href="http://www.perl6.org/">Perl 6</a> project is a new language. Perl 5 and Perl 6 are two languages in the Perl family, but of different lineages. Perl 6 is not intended as a replacement for Perl 5, but as its own thing - and libraries exist to allow you to call Perl 5 code from Perl 6 programs and vice versa.
+        The <a href="http://www.raku.org/">Raku</a> project (formerly known as Perl 6) is a new language. Perl 5 and Raku are two languages in the Perl family, but of different lineages. Raku is not intended as a replacement for Perl 5, but as its own thing - and libraries exist to allow you to call Perl 5 code from Raku programs and vice versa.
     </p>
     <h4>
         Rakudo
@@ -41,7 +41,7 @@ description => 'Resources and useful links for developers.',
         <a href="http://rakudo.org/">http://rakudo.org/</a>
     </p>
     <p>
-        Rakudo Perl is an implementation of the Perl 6 specification that runs on multiple backends, including MoarVM and the JVM.
+        Rakudo is an implementation of the Raku specification that runs on multiple backends, including MoarVM and the JVM.
     </p>
     <h4>
         MoarVM
@@ -50,7 +50,7 @@ description => 'Resources and useful links for developers.',
         <a href="http://www.moarvm.org/">http://www.moarvm.org/</a>
     </p>
     <p>
-        MoarVM is a virtual machine built especially for Rakudo Perl 6 and the NQP Compiler Toolchain.
+        MoarVM is a virtual machine built especially for Rakudo and the NQP Compiler Toolchain.
     </p>
   </div>
 </div>

--- a/docs/dev/tpl/nav_tabs.html
+++ b/docs/dev/tpl/nav_tabs.html
@@ -3,7 +3,7 @@
         <a href="/perl5/">Perl 5</a>
     </li>
     <li class="sub[% ' selected' IF page.section == 'perl6' %]">
-        <a href="http://www.perl6.org/">Perl6.org</a>
+        <a href="http://www.raku.org/">Raku.org</a>
     </li>
 
 </ul>

--- a/docs/www/about.html
+++ b/docs/www/about.html
@@ -13,7 +13,7 @@
     <p>
         Perl 5 is a highly capable, feature-rich programming language with over [% perl_stats.perl_age %] years of development. Perl 5 runs on over [% perl_stats.platforms %] platforms from portables to mainframes and is suitable for both rapid prototyping and large scale development projects.
     </p>
-    <p>"Perl" is a family of languages, "Perl 6" is part of
+    <p>"Perl" is a family of languages, "Raku" (formerly known as "Perl 6") is part of
         the family, but it is a separate language which
         has its own development team. Its existence
         has no significant impact on the continuing

--- a/docs/www/index.html
+++ b/docs/www/index.html
@@ -63,12 +63,12 @@
 </div>
 <div class="row">
   <div class="col-xs-12 col-sm-4 text-center">
-    <h3>Perl 6</h3>
-    <p>Perl 6 is a sister language, part of the Perl family,
+    <h3>Raku</h3>
+    <p>Raku (formerly known as Perl 6) is a sister language, part of the Perl family,
     not intended as a replacement for Perl 5,
     but as its own thing - libraries exist to allow you
-    to call Perl 5 code from Perl 6 programs and vice versa.</p>
-    <p><a class="btn btn-xs btn-success" href="http://www.perl6.org" role="button">View details &raquo;</a></p>
+    to call Perl 5 code from Raku programs and vice versa.</p>
+    <p><a class="btn btn-xs btn-success" href="http://www.raku.org" role="button">View details &raquo;</a></p>
   </div>
   <div class="col-xs-12 col-sm-4 text-center">
     <h3>The Perl Foundation</h3>


### PR DESCRIPTION
Perl 6 is being renamed to Raku. This allows Perl 5 to simply continue as Perl. Perl won't have a Perl 6, but is no longer beholden to the number 5 for identity or the associated confusion.

I changed links to perl6.org to raku.org, as it seems likely to be the canonical domain that will be used, but deep redirects aren't set up yet.

I did not change book descriptions or redirects.