### PR TITLE
Rename Perl 5 references to Perl

### DIFF
--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -7,13 +7,13 @@ description => 'Resources and useful links for developers.',
 %]
 <div class="row row-height">
   <div class="col-xs-12 col-sm-6">
-    <h3>Perl 5</h3>
+    <h3>Perl</h3>
     <h4>Production-ready, under active development</h4>
     <p>
         Get involved: <a href="http://dev.perl.org/perl5/">http://dev.perl.org/perl5/</a>
     </p>
     <p>
-        Perl <a href="[% perl_stats.perl_version_link %]">[% perl_stats.perl_version %]</a> is the current stable version of Perl. Perl 5 is <a href="https://www.openhub.net/p/perl/commits">actively maintained</a> and <a href="https://github.com/Perl/perl5">developed (git repository)</a> by a large group of <a href="https://www.openhub.net/p/perl/contributors">dedicated volunteers</a>. Perl 5 will be developed and maintained for many years to come.
+        Perl <a href="[% perl_stats.perl_version_link %]">[% perl_stats.perl_version %]</a> is the current stable version of Perl. Perl is <a href="https://www.openhub.net/p/perl/commits">actively maintained</a> and <a href="https://github.com/Perl/perl5">developed (git repository)</a> by a large group of <a href="https://www.openhub.net/p/perl/contributors">dedicated volunteers</a>. Perl will be developed and maintained for many years to come.
     </p>
 
     <h4>
@@ -32,7 +32,7 @@ description => 'Resources and useful links for developers.',
         <a href="http://www.raku.org/">http://www.raku.org/</a>
     </p>
     <p>
-        The <a href="http://www.raku.org/">Raku</a> project (formerly known as Perl 6) is a new language. Perl 5 and Raku are two languages in the Perl family, but of different lineages. Raku is not intended as a replacement for Perl 5, but as its own thing - and libraries exist to allow you to call Perl 5 code from Raku programs and vice versa.
+        The <a href="http://www.raku.org/">Raku</a> project (formerly known as Perl 6) is a new language. Perl and Raku are two languages in the Perl family, but of different lineages. Raku is not intended as a replacement for Perl, but as its own thing - and libraries exist to allow you to call Perl code from Raku programs and vice versa.
     </p>
     <h4>
         Rakudo

--- a/docs/dev/perl5/index.html
+++ b/docs/dev/perl5/index.html
@@ -1,14 +1,14 @@
-[% page.title = "Perl 5" %]
+[% page.title = "Perl" %]
 <div class="row row-height">
   <div class="col-xs-12 col-sm-4">
     <h3>
-      Perl 5
+      Perl
     </h3>
     <h4>
         Production-ready, under active development
     </h4>
     <p>
-        Perl <a href="[% perl_stats.perl_version_link %]">[% perl_stats.perl_version %]</a> is the current stable version of Perl. Perl 5 is <a href="https://www.openhub.net/p/perl/commits">actively maintained</a> and <a href="https://github.com/Perl/perl5">developed (git repository)</a> by a large group of <a href="https://www.openhub.net/p/perl/contributors">dedicated volunteers</a>. Perl 5 will be developed and maintained for many years to come.
+        Perl <a href="[% perl_stats.perl_version_link %]">[% perl_stats.perl_version %]</a> is the current stable version of Perl. Perl is <a href="https://www.openhub.net/p/perl/commits">actively maintained</a> and <a href="https://github.com/Perl/perl5">developed (git repository)</a> by a large group of <a href="https://www.openhub.net/p/perl/contributors">dedicated volunteers</a>. Perl will be developed and maintained for many years to come.
     </p>
   </div>
   <div class="col-xs-12 col-sm-4">

--- a/docs/dev/perl5/source.html
+++ b/docs/dev/perl5/source.html
@@ -6,7 +6,7 @@ repository, which is browseable through a web interface at <a
 href="https://github.com/Perl/perl5">https://github.com/Perl/perl5</a>.
 </p>
 
-<p>The easiest way to copy the Perl 5 repository is to use git:</p>
+<p>The easiest way to copy the Perl repository is to use git:</p>
 <pre>
   git clone https://github.com/Perl/perl5.git perl
 </pre>

--- a/docs/dev/tpl/nav_tabs.html
+++ b/docs/dev/tpl/nav_tabs.html
@@ -1,6 +1,6 @@
 <ul class="list-inline text-center nav navbar-nav navbar-right">
     <li class="sub[% ' selected' IF page.section == 'perl5' %]">
-        <a href="/perl5/">Perl 5</a>
+        <a href="/perl5/">Perl</a>
     </li>
     <li class="sub[% ' selected' IF page.section == 'perl6' %]">
         <a href="http://www.raku.org/">Raku.org</a>

--- a/docs/dev/tpl/sections/perl5_config.html
+++ b/docs/dev/tpl/sections/perl5_config.html
@@ -1,7 +1,7 @@
 [%-
 
     SET section_data = {
-        quick_links_1_title => 'Perl 5',
+        quick_links_1_title => 'Perl',
         quick_links_1_list => [
             '<a href="/perl5/news/">News</a>',
             '<a href="/perl5/lists.html">Mailing lists</a>',

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -2,7 +2,7 @@
     page.import({
         title => 'Learn Perl',
         section  => 'home',
-        description => "Helping you get started with Perl 5."
+        description => "Helping you get started with Perl."
         keywords => 'Learn Perl 5, beginning Perl, Perl, Perl tutorials, Perl FAQ, Perl documentation',
     });
 -%]
@@ -34,7 +34,7 @@
     <h3> What would you like to learn?</h3>
     <ul class="list-unstyled">
         <li>
-            · <a href="/installing/">Installing Perl 5 - and setup guide</a>
+            · <a href="/installing/">Installing Perl - and setup guide</a>
         </li>
         <li>
             · <a href="/first_steps/">First program - and some basic best

--- a/docs/shared/tpl/style/perlweb_bootstrap.html
+++ b/docs/shared/tpl/style/perlweb_bootstrap.html
@@ -69,9 +69,9 @@
       <div class="container text-center">
         <img src="[% combust.static_url("/images/icons/header_camel.png") %]" class="img-camel" alt="Perl5 Camel">
         <div class="over-image">
-          <h2>[% combust.site == 'www' ? 'That\'s why we love Perl 5' : page.title %]</h2>
+          <h2>[% combust.site == 'www' ? 'That\'s why we love Perl' : page.title %]</h2>
           <h1>[% headline || site.tag_line %]</h1>
-          <p>[% combust.site == 'www' ? 'Perl 5 is a highly capable, feature-rich programming language with over ' _  perl_stats.perl_age _ ' years of development.' : page.description %]</p>
+          <p>[% combust.site == 'www' ? 'Perl is a highly capable, feature-rich programming language with over ' _  perl_stats.perl_age _ ' years of development.' : page.description %]</p>
           <p>
             <a class="btn btn-success" href="[% site.url || 'http://www.perl.org/get.html' %]" role="button">
               [% IF combust.site == 'www' || combust.site == 'learn' %]<img src="[% combust.static_url("/images/icons/ic_download.svg") %]" class="btn-ic hidden-xs">[% END %]<span class="hidden-xs">[% site.link || 'Download and Get Started' %]</span><span class="visible-xs">Learn more »</span></a>

--- a/docs/www/about.html
+++ b/docs/www/about.html
@@ -11,24 +11,24 @@
   <div class="col-xs-12 col-sm-6">
     <h3>Powerful, stable, mature, portable</h3>
     <p>
-        Perl 5 is a highly capable, feature-rich programming language with over [% perl_stats.perl_age %] years of development. Perl 5 runs on over [% perl_stats.platforms %] platforms from portables to mainframes and is suitable for both rapid prototyping and large scale development projects.
+        Perl is a highly capable, feature-rich programming language with over [% perl_stats.perl_age %] years of development. Perl runs on over [% perl_stats.platforms %] platforms from portables to mainframes and is suitable for both rapid prototyping and large scale development projects.
     </p>
     <p>"Perl" is a family of languages, "Raku" (formerly known as "Perl 6") is part of
         the family, but it is a separate language which
         has its own development team. Its existence
         has no significant impact on the continuing
-        development of "Perl 5".
+        development of "Perl".
     </p>
   </div>
   <div class="col-xs-12 col-sm-6">
     <h3>White papers: Technical Showcases</h3>
-    <p><a href="/about/whitepapers/">White papers</a> of Perl 5 technology at your disposal.</p>
+    <p><a href="/about/whitepapers/">White papers</a> of Perl technology at your disposal.</p>
     <ul class="list-unstyled">
         [% INCLUDE 'about/whitepapers/whitepapers_list.html' %]
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
-    <h3>Perl5 features</h3>
+    <h3>Perl features</h3>
     <h4>
         Mission critical
     </h4>
@@ -85,7 +85,7 @@
     </p>
   </div>
   <div class="col-xs-12 col-sm-6">
-    <h3>Perl5 and the Web</h3>
+    <h3>Perl and the Web</h3>
     <h4>
         Ideal web programming language
     </h4>

--- a/docs/www/contribute.html
+++ b/docs/www/contribute.html
@@ -13,7 +13,7 @@
     <p>
       <a href="https://www.cpan.org/misc/cpan-faq.html#How_contribute_modules">Contribute modules to CPAN</a>
     </p>
-    <p><a href="http://dev.perl.org/perl5/">Contribute to Perl 5 Core</a></p>
+    <p><a href="http://dev.perl.org/perl5/">Contribute to Perl Core</a></p>
   </div>
   <div class="col-xs-12 col-sm-4">
     <h3>Join the community</h3>

--- a/docs/www/index.html
+++ b/docs/www/index.html
@@ -22,7 +22,7 @@
     <a href="/learn.html" class="highlight-module">
       <h3 class="alternate">Learning</h3>
       <img src="[% combust.static_url("/images/icons/ic_highlight_pencil.svg") %]" class="ic-highlight">
-      <p>With free online books, over [% perl_stats.cpan_dists %] extension modules, and a large developer community, there are many ways to learn Perl 5.</p>
+      <p>With free online books, over [% perl_stats.cpan_dists %] extension modules, and a large developer community, there are many ways to learn Perl.</p>
     </a>
   </div>
   <div class="col-xs-12 col-sm-4">
@@ -65,9 +65,9 @@
   <div class="col-xs-12 col-sm-4 text-center">
     <h3>Raku</h3>
     <p>Raku (formerly known as Perl 6) is a sister language, part of the Perl family,
-    not intended as a replacement for Perl 5,
+    not intended as a replacement for Perl,
     but as its own thing - libraries exist to allow you
-    to call Perl 5 code from Raku programs and vice versa.</p>
+    to call Perl code from Raku programs and vice versa.</p>
     <p><a class="btn btn-xs btn-success" href="http://www.raku.org" role="button">View details &raquo;</a></p>
   </div>
   <div class="col-xs-12 col-sm-4 text-center">

--- a/docs/www/tpl/sections/contribute_config.html
+++ b/docs/www/tpl/sections/contribute_config.html
@@ -3,7 +3,7 @@
     SET section_data = {
         quick_links_1_title => 'Related sites',
         quick_links_1_list => [
-            '<a  href="http://dev.perl.org/perl5/">Perl 5 Core development</a>',
+            '<a  href="http://dev.perl.org/perl5/">Perl Core development</a>',
             '<a  href="http://www.cpan.org/misc/cpan-faq.html#How_contribute_modules">CPAN Modules</a>',
         ],
     };


### PR DESCRIPTION
Enabled by #297 

Perl 6 is being renamed to Raku. This allows Perl 5 to simply continue as Perl. Perl won't have a Perl 6, but is no longer beholden to the number 5 for identity or the associated confusion.