### PR TITLE
Remove documentation on retrieving source with rsync

### DIFF
--- a/docs/dev/perl5/source.html
+++ b/docs/dev/perl5/source.html
@@ -15,19 +15,6 @@ href="https://github.com/Perl/perl5">https://github.com/Perl/perl5</a>.
 depending on the maintenance version.
 </p>
 
-<p>For people who can't or don't want to use git, the latest sources
-are also available through rsync:
-</p>
-<pre>
-  rsync -avz rsync://perl5.git.perl.org/APC/perl-current .
-</pre>
-<p>or, for the maintenance branches:</p>
-<pre>
-  rsync -avz rsync://perl5.git.perl.org/APC/perl-5.10.x .
-  rsync -avz rsync://perl5.git.perl.org/APC/perl-5.8.x .
-</pre>
-
-
 <p>
 For more details on working with the Perl source code, please see the
 <a href="http://perldoc.perl.org/perlhack.html#GETTING-THE-PERL-SOURCE"


### PR DESCRIPTION
As mentioned in #296, the rsync method is sort of obsolete and it can be left up to perldoc perlhack to describe this.