### PR TITLE
fix broken link

### DIFF
--- a/docs/www/tpl/sections/cpan_config.html
+++ b/docs/www/tpl/sections/cpan_config.html
@@ -3,8 +3,8 @@
     SET section_data = {
         quick_links_1_title => 'Related sites',
         quick_links_1_list => [
-        	'<a href="http://www.cpan.org/">CPAN</a>',
-        	'<a href="https://metacpan.org/release">metacpan</a>',
+            '<a href="http://www.cpan.org/">CPAN</a>',
+            '<a href="https://metacpan.org/">MetaCPAN</a>',
             '<a href="http://cpanratings.perl.org/">CPAN ratings</a>',
         ],
     };


### PR DESCRIPTION
There is no https://metacpan.org/release.

I would argue that the entire _related_ section on that particular page is obsolete as all its content is already there above. Could that be removed?

![image](https://user-images.githubusercontent.com/1125067/114173051-6cedc800-992e-11eb-8c1f-0f64cd783f9c.png)
