### PR TITLE
fix spelling of MetaCPAN

### DIFF
--- a/docs/learn/modules/index.html
+++ b/docs/learn/modules/index.html
@@ -36,7 +36,7 @@
 
 <h3>Which modules should I use?</h3>
 <p>
-    Metacpan has user ratings, also have a look at
+    MetaCPAN has user ratings, also have a look at
     <a href="https://metacpan.org/release/Task-Kensho/">Task::Kensho</a>.
     The <a href="/examples/">examples</a> section and <a href="/faq/">FAQ</a>
     also have some recommendations, you could also ask the Perl <a href="http://www.perl.org/community.html">community</a>.

--- a/docs/perl4lib/index.html
+++ b/docs/perl4lib/index.html
@@ -1,17 +1,17 @@
 [% page.title = "Perl4lib" %]
 
 <p>Welcome to the perl4lib mailing list homepage. perl4lib is an unmoderated and
-open list for discussing the use of Perl in library and information science. 
-It has been established to encourage beginning Perl programmers, and to 
-provide a forum for the exchange of programs, projects and ideas by active 
+open list for discussing the use of Perl in library and information science.
+It has been established to encourage beginning Perl programmers, and to
+provide a forum for the exchange of programs, projects and ideas by active
 Perl programmers.</p>
 
-<p>As many of us have discovered, Perl is not that difficult to learn, with the 
+<p>As many of us have discovered, Perl is not that difficult to learn, with the
 help of some simple examples, a book and a network of helpful colleagues.</p>
 
 <h2>Administrivia</h2>
 <p>
-perl4lib is hosted at perl.org using the ezmlm mailing list manager which 
+perl4lib is hosted at perl.org using the ezmlm mailing list manager which
 receives all commands using specially crafted to addresses. To subscribe,
 unsubscribe, or contribute to the list use one of the following addresses:
 
@@ -20,7 +20,7 @@ perl4lib-subscribe@perl.org<br>
 perl4lib-unsubscribe@perl.org<br>
 </div>
 
-perl4lib is a relatively low volume list, however if you are interested in 
+perl4lib is a relatively low volume list, however if you are interested in
 receiving a digest version use the following addresses:
 
 <div class="code">
@@ -39,16 +39,16 @@ perl4lib-help@perl.org<br>
 <h2>Archives</h2>
 
 <p>
-Past messages are <a href="http://www.nntp.perl.org/group/perl.perl4lib">available</a> for browsing on the web, via your favorite news reader, or as an RSS 
+Past messages are <a href="http://www.nntp.perl.org/group/perl.perl4lib">available</a> for browsing on the web, via your favorite news reader, or as an RSS
 feed. If you want to search past messages jump over to the <a href="http://www.mail-archive.com/perl4lib%40perl.org/">mail-archive</a>.
 
 <p>
 
 <h2>Projects</h2>
 <p>
-Perl's text-friendliness makes it ideally suited to many library related 
-tasks. The true utility of Perl in libraries can be seen by browsing the  
-<a href="http://www.cpan.org">CPAN</a>. To get you started here is an 
+Perl's text-friendliness makes it ideally suited to many library related
+tasks. The true utility of Perl in libraries can be seen by browsing the
+<a href="http://www.cpan.org">CPAN</a>. To get you started here is an
 incomplete list of relevant projects. Please subscribe and email the list
 if you have any suggestions.
 
@@ -63,7 +63,7 @@ if you have any suggestions.
 
 <h2>Libraries</h2>
 
-There is a lot of libraries for libraries over there. Just search on <a href="https://metacpan.org/">Metacpan</a> about MARC, OAI, RDF, ... My personnal notes about MARC:
+There is a lot of libraries for libraries over there. Just search on <a href="https://metacpan.org/">MetaCPAN</a> about MARC, OAI, RDF, ... My personnal notes about MARC:
 
 <ul>
     <li>MARC::Record is the de facto standard, very mature implementation but painfull API
@@ -84,7 +84,7 @@ system which uses Amazon as a data source.</li>
 <h2>Old list of libraries</h2>
 </ul>
 
-<p> Still need it? metacpan rocks  ...  </p> 
+<p> Still need it? MetaCPAN rocks  ...  </p>
 
 
 <ul>
@@ -115,7 +115,7 @@ simple <a href="http://www.loc.gov/z3950/agency/zing/srw/sru.html">SRU</a> serve
 <li><a href="http://search.cpan.org/dist/HTML-DublinCore">HTML::DublinCore</a>: easily extract Dublin Core data from HTML</a></li>
 <li><a href="http://docarc.sourceforge.net/">Document Archive</a>: a document
 tracking system.</li>
-<li<a href="http://search.cpan.org/perldoc?Biblio::Isis">Biblio::Isis</a>: 
+<li<a href="http://search.cpan.org/perldoc?Biblio::Isis">Biblio::Isis</a>:
 Read CDS/ISIS, WinISIS and IsisMarc databases.</li>
 <li><a href="http://search.cpan.org/perldoc?HTTP::OAI">HTTP::OAI</a>: API for the OAI-PMH.</li>
 <li><a href="http://search.cpan.org/perldoc?URI::OpenURL">URI::OpenURL</a>:
@@ -125,10 +125,10 @@ Parse and construct OpenURL's (NISO Z39.88-2004)</li>
 
 <h2>History</h2>
 
-<p>The perl4lib listserv was originally hosted by the Virginia Institute of 
-Marine Science (VIMS), and began as a follow on to A Perl Toolkit for 
-Libraries which was a workshop sponsored by the Virginia Library Association 
-on June 7, 1999. From there the list moved to Rice University for a few years 
+<p>The perl4lib listserv was originally hosted by the Virginia Institute of
+Marine Science (VIMS), and began as a follow on to A Perl Toolkit for
+Libraries which was a workshop sponsored by the Virginia Library Association
+on June 7, 1999. From there the list moved to Rice University for a few years
 until it moved to it's current location at perl.org</p>
 
 </p>

--- a/docs/www/tpl/sections/docs_config.html
+++ b/docs/www/tpl/sections/docs_config.html
@@ -9,7 +9,7 @@
         quick_links_2_title => 'Related sites',
         quick_links_2_list => [
             '<a href="http://perldoc.perl.org/">Perldoc</a>',
-            '<a href="https://metacpan.org/">metacpan</a>',
+            '<a href="https://metacpan.org/">MetaCPAN</a>',
             '<a href="http://learn.perl.org/">Learn</a>',
         ],
     };


### PR DESCRIPTION
This spelling is taken from https://metacpan.org/about, which is
probably the official source of truth.

I've left out the file I changed in #345.