### PR TITLE
community - add libera.chat #perl

### DIFF
--- a/docs/www/community.html
+++ b/docs/www/community.html
@@ -53,6 +53,9 @@
         <li>
             <a href="http://www.irc.perl.org">irc.perl.org</a> (<a href="http://www.irc.perl.org/channels.html">channel list</a>)
         </li>
+        <li>
+            <a href="https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#perl">#perl on libera.chat</a>
+        </li>
     </ul>
   </div>
 


### PR DESCRIPTION
The freenode channel used to be listed but was changed to a scrollback link in https://github.com/perlorg/perlweb/commit/e2b508785a0b9025f80f72fc1337b7fdaff46aee which was then removed in https://github.com/perlorg/perlweb/commit/722ffc74491a47b5fec249161cb54334c4437384 because it no longer works. The freenode channel has now moved to libera.chat.