### PR TITLE
Remove or edit broken links

### DIFF
--- a/docs/dbi/index.html
+++ b/docs/dbi/index.html
@@ -27,7 +27,7 @@
             <a href="https://metacpan.org/pod/DBI">Perldoc</a>
         </li>
         <li>
-            <a href="https://metacpan.org/changes/distribution/DBI">Changes</a>
+            <a href="https://metacpan.org/dist/DBI/changes">Changes</a>
         </li>
         <li>
             <a href="https://metacpan.org/release/DBI">Full content</a>

--- a/docs/debugger/resources.html
+++ b/docs/debugger/resources.html
@@ -5,7 +5,7 @@
 
 <h2>Books</h2>
 
-<a href="http://www.oreilly.com/catalog/perldebugpr/"><em>Perl Debugger Pocket Reference</em></a> by Richard Foley<p>
+<em>Perl Debugger Pocket Reference</em> by Richard Foley<p>
 <em>Perl Debugged</em> by Peter Scott and Ed Wright<p>
  This book provides you with excellent tips that will help you avoid a number of bugs
  and shows you ways to find bugs once they made their way into your code.

--- a/docs/dev/tpl/sections/perl6_config.html
+++ b/docs/dev/tpl/sections/perl6_config.html
@@ -13,7 +13,7 @@
         quick_links_2_title => 'Related sites',
         quick_links_2_list => [
             '<a href="http://www.perlfoundation.org/perl6/index.cgi?perl_6">Perl 6 Wiki</a>',
-            '<a href="http://rakudo.org/how-to-get-rakudo">Rakudo Perl 6</a>',
+            '<a href="http://rakudo.org/">Rakudo Perl 6</a>',
         ],
     };
 

--- a/docs/qa/testing/index.html
+++ b/docs/qa/testing/index.html
@@ -11,7 +11,7 @@
       Testing cheat sheets
   </h3>
   <p>
-      Ian Langworth, author of <cite><a href="http://oreilly.com/catalog/9780596100926">Perl Testing: A Developer's Notebook</a></cite> has put together a tremendous <a href="https://github.com/statico/perl-test-refcard/raw/master/perl_test_refcard.pdf">Perl testing quick reference card</a>.
+      Ian Langworth, author of <cite><a href="https://www.oreilly.com/library/view/perl-testing-a/0596100922/">Perl Testing: A Developer's Notebook</a></cite> has put together a tremendous <a href="https://github.com/statico/perl-test-refcard/raw/master/perl_test_refcard.pdf">Perl testing quick reference card</a>.
   </p>
   <h3>
       Testing articles
@@ -21,16 +21,16 @@
   </p>
   <ul>
       <li>
-          <a href="http://www.perl.com/pub/a/2004/10/21/taint_testing_kata.html">Testing Taint</a>
+          <a href="https://www.perl.com/pub/2004/10/21/taint_testing_kata.html/">Testing Taint</a>
       </li>
       <li>
-          <a href="http://www.perl.com/pub/a/2004/12/16/import_kata.html">Testing Imports</a>
+          <a href="https://www.perl.com/pub/2004/12/16/import_kata.html/">Testing Imports</a>
       </li>
       <li>
-          <a href="http://www.perl.com/lpt/a/2005/02/10/database_kata.html">Testing Databases</a>
+          <a href="https://www.perl.com/pub/2005/02/10/database_kata.html/">Testing Databases</a>
       </li>
       <li>
-          <a href="http://www.perl.com/pub/a/2005/04/07/mockobject_kata.html">Mocking Objects</a>
+          <a href="https://www.perl.com/pub/2005/04/07/mockobject_kata.html/">Mocking Objects</a>
       </li>
   </ul>
   <h3>

--- a/docs/www/advocacy/white_camel/2012.html
+++ b/docs/www/advocacy/white_camel/2012.html
@@ -33,7 +33,7 @@ page.import({
 <p>
     Breno G. de Oliveira, or just "garu", is a social connector in the
     Brasilian Perl community as well as the <a href="http://sdl.perl.org/">PerlSDL</a> community. Active in
-    <a href="http://rio.pm.org/">Rio.pm</a>, he's was also the organizer of <a href="http://yapcbrasil.org.br/2011/">YAPC::Brasil 2011</a> in Rio de
+    <a href="http://rio.pm.org/">Rio.pm</a>, he's was also the organizer of YAPC::Brasil 2011 in Rio de
     Janeiro. He's contributed to the PerlSDL book. With a little help, he
     wants to unite the global Perl community by visiting every YAPC he can
     and helping other people to travel to Brasil to meet Perl programmers

--- a/docs/www/advocacy/white_camel/2014.html
+++ b/docs/www/advocacy/white_camel/2014.html
@@ -11,7 +11,7 @@ page.import({
     Perl Community: Amalia Pomian
 </h3>
 <p>
-Amalia Pomian takes care of everything when organizing the <a href="http://cluj.pm">cluj.pm</a> events: booking the place to hold the meetings, creating the schwag, taking care that the guest speakers have a great itinerary here, arranging the talks, promoting the events, keeping in touch with all the participants, and most other things.
+Amalia Pomian takes care of everything when organizing the cluj.pm events: booking the place to hold the meetings, creating the schwag, taking care that the guest speakers have a great itinerary here, arranging the talks, promoting the events, keeping in touch with all the participants, and most other things.
 </p>
 <h3>
     Perl User Groups: VM Brasseur

--- a/docs/www/advocacy/white_camel/2015.html
+++ b/docs/www/advocacy/white_camel/2015.html
@@ -21,5 +21,5 @@ You can hardly go to a Perl conference (or <a href="http://amsterdamx.pm.org">Am
 <h3>Perl Community - Steffen Müller</h3>
 
 <p>
-Steffen Müller, also known as tsee, has done quite a bit of technical work for the Perl community, but he's one of the people helping with the non-technical aspects in too many ways to mention. He's especially stood out in recent years with his work through Booking.com, writing for <a href="http://blog.booking.com/author/steffen-muller.html">their technical blog</a> and being a driving force behind <a href="http://news.perlfoundation.org/2015/08/bookingcom-donate-60000-to-per-1.html">Booking.com's generous donations</a> to The <a href="http://www.perlfoundation.org/perl_5_core_maintenance_fund">Core Maintenance Fund</a>.
+Steffen Müller, also known as tsee, has done quite a bit of technical work for the Perl community, but he's one of the people helping with the non-technical aspects in too many ways to mention. He's especially stood out in recent years with his work through Booking.com, writing for their technical blog and being a driving force behind <a href="https://news.perlfoundation.org/post/bookingcom_donate_60000_to_per_1">Booking.com's generous donations</a> to The <a href="https://www.perlfoundation.org/perl-core-development-fund.html">Core Maintenance Fund</a>.
 </p>

--- a/docs/www/advocacy/white_camel/2017.html
+++ b/docs/www/advocacy/white_camel/2017.html
@@ -15,7 +15,7 @@ Laurent Boivin has been the treasurer of <A href="http://www.mongueurs.net">Les 
 <h3>Perl Advocacy - Rob Masic</h3>
 
 <p>
-Rob Masic is one of the co-founders of <a href="https://www.evozon.com">Evozon</a> through which much Perly goodness flows. Evozon hosted YAPC::EU 2016 in Cluj and sponsors many other Perl events around the world. They support the local Perl mongers group, <a href="https://cluj.pm">Cluj.pm</a>. They donated time with their graphic designers for YAPC::EU 2014 in Sofia and for various Perl website redesigns. They created <a href="http://www.builtinperl.com">BuiltinPerl</a>. Without the generosity of the entire company many of these things couldn't have happened. (<a href="https://www.perl.org/advocacy/white_camel/2014.html">Amalia Pomian from Evozon was a 2014 White Camel Award recipient</a>)
+Rob Masic is one of the co-founders of <a href="https://www.evozon.com">Evozon</a> through which much Perly goodness flows. Evozon hosted YAPC::EU 2016 in Cluj and sponsors many other Perl events around the world. They support the local Perl mongers group, cluj.pm. They donated time with their graphic designers for YAPC::EU 2014 in Sofia and for various Perl website redesigns. They created <a href="http://www.builtinperl.com">BuiltinPerl</a>. Without the generosity of the entire company many of these things couldn't have happened. (<a href="https://www.perl.org/advocacy/white_camel/2014.html">Amalia Pomian from Evozon was a 2014 White Camel Award recipient</a>)
 </p>
 
 <h3>Perl Community - Kurt Demaagd</h3>

--- a/docs/www/camel.html
+++ b/docs/www/camel.html
@@ -11,7 +11,7 @@
     <p>
         The Camel has been the symbol of Perl since its appearance on the
         cover of the first edition
-        of <a href="http://oreilly.com/catalog/9780596000271" >Programming
+        of <a href="https://www.oreilly.com/library/view/programming-perl-4th/9781449321451/" >Programming
         Perl</a>. The camel with the topic of Perl is a trademark of
         <a href="http://www.ora.com">O’Reilly Media, Inc.</a>
         Used with permission.

--- a/docs/www/siteinfo.html
+++ b/docs/www/siteinfo.html
@@ -190,7 +190,7 @@
         <td>
             <p>
                 This site is powered
-                by <a href="http://git.develooper.com/combust.git">Combust!</a>
+                by <a href="https://github.com/abh/combust.git">Combust!</a>
             </p>
         </td>
     </tr>


### PR DESCRIPTION
- Cluj.pm just expired
- No blog for Steffen, edit TPF links
- Combust repository moved
- Edit Programming Perl link + upgrade to 4th edition
- Edit Perl testing link
- Dead link
- Edit link for DBI changelog
- Perl Debugger Pocket Reference is no longer listed on oreilly website
- Edit some perl.com links
- Dead yapcbrasil link