### PR TITLE
Fix HTML and OSI link for GPL-1

### DIFF
--- a/docs/dev/licenses/gpl1.html
+++ b/docs/dev/licenses/gpl1.html
@@ -5,7 +5,7 @@
 <PRE>
 
 <A style="float:right" 
-   HREF="http://www.opensource.org/licenses/gpl-license.php"
+   HREF="https://opensource.org/license/gpl-1-0"
 ><IMG BORDER=0 SRC="osi-certified-90x75.gif"
 ></A>
 
@@ -213,8 +213,8 @@ attach them to the start of each source file to most effectively convey
 the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 19yy  <name of author>
+    &lt;one line to give the program's name and a brief idea of what it does.&gt;
+    Copyright (C) 19yy  &lt;name of author&gt;
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -254,7 +254,7 @@ necessary.  Here a sample; alter the names:
   program `Gnomovision' (a program to direct compilers to make passes
   at assemblers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
+  &lt;signature of Ty Coon&gt;, 1 April 1989
   Ty Coon, President of Vice
 
 That's all there is to it!


### PR DESCRIPTION
The old OSI link redirects to GPL v3, not v1.

Unescaped `<` effectively hide text from browsers (treated as an unknown tag), even in a `<PRE>` section.