### PR TITLE
Fix OSI link for Artistic License

### DIFF
--- a/docs/dev/licenses/artistic.html
+++ b/docs/dev/licenses/artistic.html
@@ -5,7 +5,7 @@
 <PRE>
 
 <A style="float:right" 
-   HREF="http://www.opensource.org/licenses/artistic-license.php"
+   HREF="https://opensource.org/license/artistic-perl-1-0-2"
 ><IMG BORDER=0 SRC="osi-certified-90x75.gif"
 ></A>
 


### PR DESCRIPTION
The old link was 404.