### PR TITLE
update GPL/Artistic license files from perl5/blead

### DIFF
--- a/docs/dev/licenses/artistic.html
+++ b/docs/dev/licenses/artistic.html
@@ -9,9 +9,12 @@
 ><IMG BORDER=0 SRC="osi-certified-90x75.gif"
 ></A>
 
-			 The "Artistic License"
 
-				Preamble
+
+
+                         The "Artistic License"
+
+                                Preamble
 
 The intent of this document is to state the conditions under which a
 Package may be copied, such that the Copyright Holder maintains some
@@ -22,30 +25,30 @@ reasonable modifications.
 
 Definitions:
 
-	"Package" refers to the collection of files distributed by the
-	Copyright Holder, and derivatives of that collection of files
-	created through textual modification.
+        "Package" refers to the collection of files distributed by the
+        Copyright Holder, and derivatives of that collection of files
+        created through textual modification.
 
-	"Standard Version" refers to such a Package if it has not been
-	modified, or has been modified in accordance with the wishes
-	of the Copyright Holder as specified below.
+        "Standard Version" refers to such a Package if it has not been
+        modified, or has been modified in accordance with the wishes
+        of the Copyright Holder as specified below.
 
-	"Copyright Holder" is whoever is named in the copyright or
-	copyrights for the package.
+        "Copyright Holder" is whoever is named in the copyright or
+        copyrights for the package.
 
-	"You" is you, if you're thinking about copying or distributing
-	this Package.
+        "You" is you, if you're thinking about copying or distributing
+        this Package.
 
-	"Reasonable copying fee" is whatever you can justify on the
-	basis of media cost, duplication charges, time of people involved,
-	and so on.  (You will not be required to justify it to the
-	Copyright Holder, but only to the computing community at large
-	as a market that must bear the fee.)
+        "Reasonable copying fee" is whatever you can justify on the
+        basis of media cost, duplication charges, time of people involved,
+        and so on.  (You will not be required to justify it to the
+        Copyright Holder, but only to the computing community at large
+        as a market that must bear the fee.)
 
-	"Freely Available" means that no fee is charged for the item
-	itself, though there may be fees involved in handling the item.
-	It also means that recipients of the item may redistribute it
-	under the same conditions they received it.
+        "Freely Available" means that no fee is charged for the item
+        itself, though there may be fees involved in handling the item.
+        It also means that recipients of the item may redistribute it
+        under the same conditions they received it.
 
 1. You may make and give away verbatim copies of the source form of the
 Standard Version of this Package without restriction, provided that you
@@ -133,7 +136,7 @@ products derived from this software without specific prior written permission.
 
 10. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
 IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
-WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
-				The End
+                                The End
 </PRE>

--- a/docs/dev/licenses/gpl1.html
+++ b/docs/dev/licenses/gpl1.html
@@ -9,16 +9,16 @@
 ><IMG BORDER=0 SRC="osi-certified-90x75.gif"
 ></A>
 
-
-		    GNU GENERAL PUBLIC LICENSE
-		     Version 1, February 1989
+                    GNU GENERAL PUBLIC LICENSE
+                     Version 1, February 1989
 
  Copyright (C) 1989 Free Software Foundation, Inc.
-                59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+               &lt;<A HREF="https://fsf.org/">https://fsf.org/</A>&gt;
+
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The license agreements of most software companies try to keep users
 at the mercy of those companies.  By contrast, our General Public
@@ -59,7 +59,7 @@ authors' reputations.
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-		    GNU GENERAL PUBLIC LICENSE
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License Agreement applies to any program or other work which
@@ -177,7 +177,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   9. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -199,9 +199,9 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
-	Appendix: How to Apply These Terms to Your New Programs
+        Appendix: How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to humanity, the best way to achieve this is to make it
@@ -227,8 +227,8 @@ the exclusion of warranty; and each file should have at least the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software Foundation,
-    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+    along with this program; if not, see &lt;<A HREF="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</A>&gt;.
+
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -254,8 +254,8 @@ necessary.  Here a sample; alter the names:
   program `Gnomovision' (a program to direct compilers to make passes
   at assemblers) written by James Hacker.
 
-  &lt;signature of Ty Coon&gt;, 1 April 1989
-  Ty Coon, President of Vice
+  &lt;signature of Moe Ghoul&gt;, 1 April 1989
+  Moe Ghoul, President of Vice
 
 That's all there is to it!
 </PRE>


### PR DESCRIPTION
The text of the GPLv1 and Artistic License files has been updated with the latest versions (at the time of writing) in the perl source tree; see <https://github.com/Perl/perl5/blob/blead/Copying> and <https://github.com/Perl/perl5/blob/blead/Artistic>, respectively.

For Artistic, no further changes were necessary (the file does not contain &<> or URLs).

For Copying, the text was converted to HTML as follows:

- `s/</&lt;/g`
- `s/>/&gt;/g`
- `s!&lt;(https?://\S*?)&gt;!&lt;<A HREF="$1">$1</A>&gt;!g`  
  (turning URLs into hyperlinks)