### PR TITLE
Point to cpan.org table for current and previous releases.

### DIFF
--- a/docs/dev/perl5/index.html
+++ b/docs/dev/perl5/index.html
@@ -25,16 +25,12 @@
   <div class="col-xs-12 col-sm-4">
     <h3>Releases</h3>
     <ul>
-      <li>
-        Latest development release
-        is <a href="https://perldoc.perl.org/5.43.5/perldelta">Perl 5.43.5</a>
-      </li>
       <li>Current major release is
         <a href="[% perl_stats.perl_version_link %]"
            >[% perl_stats.perl_version %]</a></li>
-
-      <li><a href="http://www.cpan.org/src/README.html"
-             >Previous Releases</a></li>
+      <li>
+        Latest development and previous <a href="http://www.cpan.org/src/README.html">releases</a>
+      </li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This will remove a manual step from the release management process for BLEAD-POINT.